### PR TITLE
Update dependencies and fix a few PHP8 support issues

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -6,7 +6,7 @@ default:
     extensions:
         DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
 
-        Lakion\Behat\MinkDebugExtension:
+        FriendsOfBehat\MinkDebugExtension\ServiceContainer\MinkDebugExtension:
             directory: etc/build
             clean_start: false
             screenshot: true

--- a/composer.json
+++ b/composer.json
@@ -5,22 +5,22 @@
     "description": "Omnisend plugin for Sylius.",
     "license": "MIT",
     "require": {
-        "php": "^7.3",
+        "php": "^7.4|^8.0",
         "guzzlehttp/psr7": "^1.7",
         "http-interop/http-factory-guzzle": "^1.0",
         "php-http/guzzle6-adapter": "^2.0",
         "php-http/httplug": "^2.0",
         "php-http/httplug-bundle": "^1.19",
-        "sylius/sylius": "^1.7",
-        "symfony/property-info": "^4.4|^5.0",
-        "symfony/serializer": "^4.4|^5.0",
-        "symfony/lock": "^4.4|^5.0",
-        "symfony/messenger": "^4.4|^5.0"
+        "sylius/sylius": "^1.10",
+        "symfony/property-info": "^4.4|^5.4",
+        "symfony/serializer": "^4.4|^5.4",
+        "symfony/lock": "^4.4|^5.4",
+        "symfony/messenger": "^4.4|^5.4"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",
         "behat/mink-selenium2-driver": "^1.4",
-        "coduo/php-matcher": "^5.0",
+        "coduo/php-matcher": "^6.0",
         "dmore/behat-chrome-extension": "^1.3",
         "dmore/chrome-mink-driver": "^2.7",
         "friends-of-behat/mink": "^1.8",
@@ -30,22 +30,21 @@
         "friends-of-behat/suite-settings-extension": "^1.0",
         "friends-of-behat/symfony-extension": "^2.1",
         "friends-of-behat/variadic-extension": "^1.3",
-        "lakion/mink-debug-extension": "^1.2.3",
-        "phpspec/phpspec": "^6.1",
+        "friends-of-behat/mink-debug-extension": "^2.1.0",
         "phpstan/extension-installer": "^1.0",
-        "phpstan/phpstan": "0.12.25",
-        "phpstan/phpstan-doctrine": "0.12.13",
-        "phpstan/phpstan-strict-rules": "^0.12.0",
-        "phpstan/phpstan-webmozart-assert": "0.12.4",
+        "phpstan/phpstan": "^1.4",
+        "phpstan/phpstan-doctrine": "^1.2",
+        "phpstan/phpstan-strict-rules": "^1.1",
+        "phpstan/phpstan-webmozart-assert": "^1.0",
         "phpunit/phpunit": "^8.5",
         "sensiolabs/security-checker": "^6.0",
-        "sylius-labs/coding-standard": "^3.1",
-        "symfony/browser-kit": "^4.4",
-        "symfony/debug-bundle": "^4.4|^5.0",
-        "symfony/dotenv": "^4.4|^5.0",
-        "symfony/intl": "^4.4|^5.0",
-        "symfony/web-profiler-bundle": "^4.4|^5.0",
-        "symfony/web-server-bundle": "^4.4|^5.0",
+        "sylius-labs/coding-standard": "^4.1",
+        "symfony/browser-kit": "^4.4|^5.4",
+        "symfony/debug-bundle": "^4.4|^5.4",
+        "symfony/dotenv": "^4.4|^5.4",
+        "symfony/intl": "^4.4|^5.4",
+        "symfony/web-profiler-bundle": "^4.4|^5.4",
+        "symfony/web-server-bundle": "^4.4|^5.4",
         "vimeo/psalm": "3.11.4"
     },
     "autoload": {
@@ -59,13 +58,13 @@
             "Tests\\NFQ\\SyliusOmnisendPlugin\\Application\\": "tests/Application/src/"
         }
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.8-dev"
-        }
-    },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/thanks": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true
+        }
     },
     "scripts": {
         "post-install-cmd": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ parameters:
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
 
-    excludes_analyse:
+    excludePaths:
         # Makes PHPStan crash
         - 'src/DependencyInjection/Configuration.php'
         - 'src/Fixture/**.php'
@@ -28,5 +28,5 @@ parameters:
         - '/Call to an undefined method Symfony\\Component\\HttpFoundation\\Session\\SessionInterface::getFlashBag\(\)./'
         - '/Method NFQ\\SyliusOmnisendPlugin\\Mapper\\EventFieldTypeDefaultValueMapper::map\(\) has no return typehint specified/'
         - '/Method NFQ\\SyliusOmnisendPlugin\\Resolver\\ProductAdditionalDataResolver::resolveAttributeValue\(\) has no return typehint specified/'
-        - '/Call to an undefined method Sylius\\Component\\Core\\Model\\CustomerInterface::isSubscribedToSMS()./'
+        - '/Call to an undefined method Sylius\\Component\\Core\\Model\\CustomerInterface::isSubscribedToSMS\(\)./'
         - '/Call to function method_exists\(\) with */'

--- a/src/EventListener/AdminMenuListener.php
+++ b/src/EventListener/AdminMenuListener.php
@@ -30,13 +30,15 @@ class AdminMenuListener
                 'nfq_sylius_omnisend_event',
                 ['route' => 'nfq_sylius_omnisend_plugin_admin_event_index']
             )
-            ->setLabel('nfq_sylius_omnisend_plugin.menu.admin.main.events');
+            ->setLabel('nfq_sylius_omnisend_plugin.menu.admin.main.events')
+            ->setLabelAttribute('icon', 'list');
 
         $submenu
             ->addChild(
                 'nfq_sylius_omnisend_sync',
                 ['route' => 'nfq_sylius_omnisend_sync_batch_index']
             )
-            ->setLabel('nfq_sylius_omnisend_plugin.menu.admin.main.sync');
+            ->setLabel('nfq_sylius_omnisend_plugin.menu.admin.main.sync')
+            ->setLabelAttribute('icon', 'refresh');
     }
 }

--- a/src/Form/Extension/ChannelFormTypeExtension.php
+++ b/src/Form/Extension/ChannelFormTypeExtension.php
@@ -38,7 +38,7 @@ class ChannelFormTypeExtension extends AbstractTypeExtension
             );
     }
 
-    public function getExtendedTypes(): array
+    public static function getExtendedTypes(): array
     {
         return [ChannelType::class];
     }

--- a/src/Resources/config/admin_routing.yml
+++ b/src/Resources/config/admin_routing.yml
@@ -3,7 +3,7 @@ nfq_sylius_omnisend_event:
     alias: nfq_sylius_omnisend_plugin.event
     section: admin
     except: ['show']
-    templates: SyliusAdminBundle:Crud
+    templates: "@SyliusAdmin\\Crud"
     redirect: update
     grid: nfq_sylius_omnisend_event
     form: NFQ\SyliusOmnisendPlugin\Form\Type\EventType

--- a/src/Resources/config/services/controllers.yaml
+++ b/src/Resources/config/services/controllers.yaml
@@ -15,6 +15,7 @@ services:
       - '@messenger.routable_message_bus'
       - '@session'
     public: true
+    tags: ['controller.service_arguments']
 
   nfq_sylius_omnisend_plugin.controller.sync:
     class: NFQ\SyliusOmnisendPlugin\Controller\SyncController
@@ -22,6 +23,7 @@ services:
       - '@sylius.context.channel.composite'
       - '@messenger.routable_message_bus'
     public: true
+    tags: ['controller.service_arguments']
 
   nfq_sylius_omnisend_plugin.controller.test:
     class: NFQ\SyliusOmnisendPlugin\Controller\TestController

--- a/src/Validator/Constraints/CustomEventFieldsValidator.php
+++ b/src/Validator/Constraints/CustomEventFieldsValidator.php
@@ -67,15 +67,15 @@ class CustomEventFieldsValidator extends ConstraintValidator
                 $validations = $this->context->getValidator()->validate($fieldValue, $fieldConstraint);
                 if ($validations->count() > 0) {
                     $this->context->buildViolation(CustomEventFields::INVALID_FIELD_VALUE)
-                        ->setParameter('%field%', $fieldName)
-                        ->setParameter('%value%', $fieldValue)
+                        ->setParameter('%field%', (string) $fieldName)
+                        ->setParameter('%value%', (string) $fieldValue)
                         ->setParameter('%type%', (string) $field->getType())
                         ->addViolation();
                 }
             } else {
                 $this->context
                     ->buildViolation(CustomEventFields::INVALID_FIELD_TYPE)
-                    ->setParameter('%field%', $fieldName)
+                    ->setParameter('%field%', (string) $fieldName)
                     ->setParameter('%type%', (string) $field->getType())
                     ->addViolation();
             }

--- a/tests/Application/Kernel.php
+++ b/tests/Application/Kernel.php
@@ -6,23 +6,11 @@ namespace Tests\NFQ\SyliusOmnisendPlugin\Application;
 
 use PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
-use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
-use Symfony\Component\DependencyInjection\Loader\DirectoryLoader;
-use Symfony\Component\DependencyInjection\Loader\GlobFileLoader;
-use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
-use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
-use Symfony\Component\HttpKernel\Config\FileLocator;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
-use Webmozart\Assert\Assert;
 
 final class Kernel extends BaseKernel
 {
@@ -73,30 +61,11 @@ final class Kernel extends BaseKernel
 
     protected function getContainerBaseClass(): string
     {
-        if ($this->isTestEnvironment()) {
+        if ($this->isTestEnvironment() && class_exists(MockerContainer::class)) {
             return MockerContainer::class;
         }
 
         return parent::getContainerBaseClass();
-    }
-
-    protected function getContainerLoader(ContainerInterface $container): LoaderInterface
-    {
-        /** @var ContainerBuilder $container */
-        Assert::isInstanceOf($container, ContainerBuilder::class);
-
-        $locator = new FileLocator($this, $this->getRootDir() . '/Resources');
-        $resolver = new LoaderResolver(array(
-            new XmlFileLoader($container, $locator),
-            new YamlFileLoader($container, $locator),
-            new IniFileLoader($container, $locator),
-            new PhpFileLoader($container, $locator),
-            new GlobFileLoader($container, $locator),
-            new DirectoryLoader($container, $locator),
-            new ClosureLoader($container),
-        ));
-
-        return new DelegatingLoader($resolver);
     }
 
     private function isTestEnvironment(): bool

--- a/tests/Application/config/bundles.php
+++ b/tests/Application/config/bundles.php
@@ -1,13 +1,12 @@
 <?php
 
-return [
+$bundles = [
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
     Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle::class => ['all' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
-    Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle::class => ['all' => true],
     Sylius\Bundle\OrderBundle\SyliusOrderBundle::class => ['all' => true],
     Sylius\Bundle\MoneyBundle\SyliusMoneyBundle::class => ['all' => true],
     Sylius\Bundle\CurrencyBundle\SyliusCurrencyBundle::class => ['all' => true],
@@ -40,7 +39,7 @@ return [
     Liip\ImagineBundle\LiipImagineBundle::class => ['all' => true],
     Payum\Bundle\PayumBundle\PayumBundle::class => ['all' => true],
     Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle::class => ['all' => true],
-    WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle::class => ['all' => true],
+    BabDev\PagerfantaBundle\BabDevPagerfantaBundle::class => ['all' => true],
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
     Sylius\Bundle\FixturesBundle\SyliusFixturesBundle::class => ['all' => true],
     Sylius\Bundle\PayumBundle\SyliusPayumBundle::class => ['all' => true],
@@ -48,8 +47,6 @@ return [
     Symfony\Bundle\WebServerBundle\WebServerBundle::class => ['all' => true],
     Sylius\Bundle\AdminBundle\SyliusAdminBundle::class => ['all' => true],
     Sylius\Bundle\ShopBundle\SyliusShopBundle::class => ['all' => true],
-    FOS\OAuthServerBundle\FOSOAuthServerBundle::class => ['all' => true],
-    Sylius\Bundle\AdminApiBundle\SyliusAdminApiBundle::class => ['all' => true],
     NFQ\SyliusOmnisendPlugin\NFQSyliusOmnisendPlugin::class => ['all' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true, 'test_cached' => true],
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true, 'test_cached' => true],
@@ -59,6 +56,12 @@ return [
     Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
     Sylius\Bundle\ApiBundle\SyliusApiBundle::class => ['all' => true],
     SyliusLabs\DoctrineMigrationsExtraBundle\SyliusLabsDoctrineMigrationsExtraBundle::class => ['all' => true],
-    Symplify\ConsoleColorDiff\ConsoleColorDiffBundle::class => ['dev' => true, 'test' => true],
     Http\HttplugBundle\HttplugBundle::class => ['all' => true],
 ];
+
+// Sylius 1.11 and above
+if (class_exists(Sylius\Calendar\SyliusCalendarBundle::class)) {
+    $bundles[Sylius\Calendar\SyliusCalendarBundle::class] = ['all' => true];
+}
+
+return $bundles;

--- a/tests/Application/config/packages/_sylius.yaml
+++ b/tests/Application/config/packages/_sylius.yaml
@@ -2,7 +2,6 @@ imports:
     - { resource: "@SyliusCoreBundle/Resources/config/app/config.yml" }
 
     - { resource: "@SyliusAdminBundle/Resources/config/app/config.yml" }
-    - { resource: "@SyliusAdminApiBundle/Resources/config/app/config.yml" }
 
     - { resource: "@SyliusShopBundle/Resources/config/app/config.yml" }
 

--- a/tests/Application/config/packages/framework.yaml
+++ b/tests/Application/config/packages/framework.yaml
@@ -2,6 +2,5 @@ framework:
     secret: '%env(APP_SECRET)%'
     form: true
     csrf_protection: true
-    templating: { engines: ["twig"] }
     session:
         handler_id: ~

--- a/tests/Application/config/packages/jms_serializer.yaml
+++ b/tests/Application/config/packages/jms_serializer.yaml
@@ -1,4 +1,4 @@
 jms_serializer:
     visitors:
-        xml:
+        xml_serialization:
             format_output: '%kernel.debug%'

--- a/tests/Application/config/packages/security.yaml
+++ b/tests/Application/config/packages/security.yaml
@@ -1,6 +1,5 @@
 parameters:
     sylius.security.admin_regex: "^/admin"
-    sylius.security.api_regex: "^/api"
     sylius.security.shop_regex: "^/(?!admin|new-api|api/.*|api$|media/.*)[^/]++"
     sylius.security.new_api_route: "/new-api"
     sylius.security.new_api_regex: "^%sylius.security.new_api_route%"
@@ -50,10 +49,6 @@ security:
                 target: sylius_admin_login
             anonymous: true
 
-        oauth_token:
-            pattern: "%sylius.security.api_regex%/oauth/v2/token"
-            security: false
-
         new_api_admin_user:
             pattern: "%sylius.security.new_api_route%/admin-user-authentication-token"
             provider: sylius_admin_user_provider
@@ -92,13 +87,6 @@ security:
             guard:
                 authenticators:
                     - lexik_jwt_authentication.jwt_token_authenticator
-
-        api:
-            pattern: "%sylius.security.api_regex%/.*"
-            provider: sylius_admin_user_provider
-            fos_oauth: true
-            stateless: true
-            anonymous: true
 
         shop:
             switch_user: { role: ROLE_ALLOWED_TO_SWITCH }
@@ -141,12 +129,10 @@ security:
         - { path: "%sylius.security.shop_regex%/_partial", role: ROLE_NO_ACCESS }
 
         - { path: "%sylius.security.admin_regex%/login", role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: "%sylius.security.api_regex%/login", role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: "%sylius.security.shop_regex%/login", role: IS_AUTHENTICATED_ANONYMOUSLY }
 
         - { path: "%sylius.security.shop_regex%/register", role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: "%sylius.security.shop_regex%/verify", role: IS_AUTHENTICATED_ANONYMOUSLY }
 
         - { path: "%sylius.security.admin_regex%", role: ROLE_ADMINISTRATION_ACCESS }
-        - { path: "%sylius.security.api_regex%/.*", role: ROLE_API_ACCESS }
         - { path: "%sylius.security.shop_regex%/account", role: ROLE_USER }

--- a/tests/Application/config/routes/sylius_admin_api.yaml
+++ b/tests/Application/config/routes/sylius_admin_api.yaml
@@ -1,3 +1,0 @@
-sylius_admin_api:
-    resource: "@SyliusAdminApiBundle/Resources/config/routing.yml"
-    prefix: /api

--- a/tests/Behat/Context/Setup/ChannelContext.php
+++ b/tests/Behat/Context/Setup/ChannelContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Tests\NFQ\SyliusOmnisendPlugin\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use NFQ\SyliusOmnisendPlugin\Model\ChannelOmnisendTrackingAwareInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\ChannelInterface;

--- a/tests/Behat/Resources/suites.yml
+++ b/tests/Behat/Resources/suites.yml
@@ -57,7 +57,7 @@ default:
                 - nfq_sylius_omnisend.context.ui.shop.customer
 
             filters:
-                tags: "@contact_registration && @ui"
+                tags: "@contact_registration&&@ui"
 
         omnisend_managing_taxons:
             contexts:
@@ -234,7 +234,7 @@ default:
                 - sylius.behat.context.ui.shop.currency
 
             filters:
-                tags: "@omnisend_modifying_address && @ui"
+                tags: "@omnisend_modifying_address&&@ui"
 
         omnisend_modifying_products:
             contexts:


### PR DESCRIPTION
- Require PHP 7.4 or above
- Require Sylius 1.10 or above (although 1.9 might work as well)
- Require currently supported Symfony versions (except 6.0, which requires a change to bootstrap.php and is not yet supported by Sylius)
- Update dev dependencies to ones which support PHP 8
- Remove phpspec from dev dependencies (it is not used and none of its releases support PHP 8.1 at the moment)
- Fix a few issues discovered after installing into Sylius 1.11 and while running tests locally
- Add icons to admin menu items
