### PR TITLE
Further fixes for controller definitions and controller/template references

### DIFF
--- a/src/Resources/config/config.yaml
+++ b/src/Resources/config/config.yaml
@@ -61,7 +61,7 @@ sylius_grid:
           type: twig
           label: sylius.ui.enabled
           options:
-            template: SyliusUiBundle:Grid/Field:enabled.html.twig
+            template: "@SyliusUi/Grid/Field/enabled.html.twig"
       actions:
         main:
           create:

--- a/src/Resources/config/services/controllers.yaml
+++ b/src/Resources/config/services/controllers.yaml
@@ -15,7 +15,8 @@ services:
       - '@messenger.routable_message_bus'
       - '@session'
     public: true
-    tags: ['controller.service_arguments']
+    calls:
+      - ['setContainer', ['@service_container']]
 
   nfq_sylius_omnisend_plugin.controller.sync:
     class: NFQ\SyliusOmnisendPlugin\Controller\SyncController
@@ -23,7 +24,8 @@ services:
       - '@sylius.context.channel.composite'
       - '@messenger.routable_message_bus'
     public: true
-    tags: ['controller.service_arguments']
+    calls:
+      - ['setContainer', ['@service_container']]
 
   nfq_sylius_omnisend_plugin.controller.test:
     class: NFQ\SyliusOmnisendPlugin\Controller\TestController

--- a/tests/Application/config/routes/test/routing.yaml
+++ b/tests/Application/config/routes/test/routing.yaml
@@ -1,5 +1,5 @@
 sylius_test_plugin_main:
     path: /test/main
-    controller: FrameworkBundle:Template:template
+    controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController::templateAction
     defaults:
         template: "@SyliusTestPlugin/main.html.twig"

--- a/tests/Application/config/routes/test/sylius_test_plugin.yaml
+++ b/tests/Application/config/routes/test/sylius_test_plugin.yaml
@@ -1,5 +1,5 @@
 sylius_test_plugin_main:
     path: /test/main
-    controller: FrameworkBundle:Template:template
+    controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController::templateAction
     defaults:
         template: "@SyliusTestPlugin/main.html.twig"

--- a/tests/Application/config/routes/test_cached/routing.yaml
+++ b/tests/Application/config/routes/test_cached/routing.yaml
@@ -1,5 +1,5 @@
 sylius_test_plugin_main:
     path: /test/main
-    controller: FrameworkBundle:Template:template
+    controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController::templateAction
     defaults:
         template: "@SyliusTestPlugin/main.html.twig"

--- a/tests/Application/config/routes/test_cached/sylius_test_plugin.yaml
+++ b/tests/Application/config/routes/test_cached/sylius_test_plugin.yaml
@@ -1,5 +1,5 @@
 sylius_test_plugin_main:
     path: /test/main
-    controller: FrameworkBundle:Template:template
+    controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController::templateAction
     defaults:
         template: "@SyliusTestPlugin/main.html.twig"


### PR DESCRIPTION
Apparently, version 1.1 still doesn't work out of the box. After installing it, I was getting the "&lt;controller&gt; has no container set, did you forget to define it as a service subscriber?" error when attempting to sync events via admin panel.

Tagging the two affected controllers with `'controller.service_arguments'` in application's `services.yaml` seemed to work,  but adding the tag from within plugin's configuration had no such effect. An explicit call to `setContainer()` actually works though.

Also, I apparently missed a template reference in "bundle notation" form previously. I fixed it now, as well as a bunch of controller references in router configuration for test env.