### PR TITLE
Bugfix: use `urlencode()` on email address in URL

### DIFF
--- a/src/Client/OmnisendClient.php
+++ b/src/Client/OmnisendClient.php
@@ -357,7 +357,7 @@ class OmnisendClient implements LoggerAwareInterface, OmnisendClientInterface
         $response = $this->sendRequest(
             $this->messageFactory->create(
                 'GET',
-                self::API_VERSION . self::URL_PATH_CONTACTS . '?email=' . $email
+                self::API_VERSION . self::URL_PATH_CONTACTS . '?email=' . urlencode($email)
             ),
             $channelCode
         );


### PR DESCRIPTION
Profiles for users with emails like foo+bar@example.com currently cannot be fetched. This patch fixes the problem.