### PR TITLE
Bugfix: reuse previously fetched contact id

### DIFF
--- a/src/Manager/ContactManager.php
+++ b/src/Manager/ContactManager.php
@@ -50,7 +50,7 @@ class ContactManager implements ContactManagerInterface
         if (null !== $contactId) {
             /** @var ContactSuccess|null $response */
             $response = $this->omnisendClient->patchContact(
-                $customer->getOmnisendContactId(),
+                $contactId,
                 $this->contactBuilderDirector->build($customer),
                 $channelCode
             );


### PR DESCRIPTION
When pushing a contact to Omnisend, Contact Manager first checks to see if a contact already exists in Omnisend. However the contact id received is not being used, but is being fetched from the contact record instead. This causes failure when the contact is actually new to Sylius (but not to Omnisend). This little change fixes that.