### PR TITLE
Do not search for order without cart id.

### DIFF
--- a/src/Message/Handler/DeleteCartHandler.php
+++ b/src/Message/Handler/DeleteCartHandler.php
@@ -41,6 +41,10 @@ class DeleteCartHandler
             $message->getChannelCode()
         );
 
+        if (null === $message->getCartId()) {
+            return;
+        }
+
         /** @var OrderInterface|null $cart */
         $cart = $this->orderRepository->find($message->getCartId());
 


### PR DESCRIPTION
Property `$cartId` is nullable so the code don't have to do a lookup for order if this property is not set.