### PR TITLE
Max image count should be 10.

### DIFF
--- a/src/Builder/Request/ProductImageListBuilder.php
+++ b/src/Builder/Request/ProductImageListBuilder.php
@@ -41,7 +41,7 @@ class ProductImageListBuilder implements ProductImageListBuilderInterface
 
         /** @var ProductImageInterface $image */
         foreach ($productImages as $image) {
-            if ($count > self::MAX_IMAGE_COUNT) {
+            if ($count === self::MAX_IMAGE_COUNT) {
                 break;
             }
             $images[] = $this->productImageFactory->create($image, $count === 0);


### PR DESCRIPTION
With an old code, 11 elements in the array is possible. This fix prevents that.