### PR TITLE
Add support for Sylius 1.13 and PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  phpunit:
+    name: PHPUnit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          extensions: ctype, curl, dom, exif, fileinfo, filter, gd, hash, iconv, intl, json, libxml, mbstring, openssl, pcre, phar, simplexml, sodium, spl, tokenizer, xml, xmlwriter
+
+      - name: Install dependencies
+        run: composer install --no-interaction
+
+      - name: Run PHPUnit tests
+        run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This plugin implements Omnisend API and all required tracking scripts.
     3. Install SSL certificates (only once needed) and run test application's webserver on `127.0.0.1:8080`:
     
       ```bash
+      wget https://get.symfony.com/cli/installer -O - | bash
       symfony server:ca:install
       APP_ENV=test symfony server:start --port=8080 --dir=tests/Application/public --daemon
       ```

--- a/composer.json
+++ b/composer.json
@@ -5,17 +5,15 @@
     "description": "Omnisend plugin for Sylius.",
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "ext-json": "*",
-        "http-interop/http-factory-guzzle": "^1.0",
-        "php-http/guzzle6-adapter": "^2.0",
         "php-http/httplug": "^2.0",
         "php-http/httplug-bundle": "^1.19",
-        "sylius/sylius": "^1.10",
-        "symfony/property-info": "^4.4 || ^5.4 || ^6.0",
-        "symfony/serializer": "^4.4 || ^5.4 || ^6.0",
-        "symfony/lock": "^4.4 || ^5.4 || ^6.0",
-        "symfony/messenger": "^4.4 || ^5.4 || ^6.0"
+        "sylius/sylius": "~1.13.1",
+        "symfony/lock": "^6.4",
+        "symfony/messenger": "^5.4 || ^6.0",
+        "symfony/property-info": "^5.4 || ^6.0",
+        "symfony/serializer": "^5.4 || >=6.0 <6.4"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",
@@ -36,14 +34,14 @@
         "phpstan/phpstan-doctrine": "^1.2",
         "phpstan/phpstan-strict-rules": "^1.1",
         "phpstan/phpstan-webmozart-assert": "^1.0",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^10.5",
         "sensiolabs/security-checker": "^6.0",
         "sylius-labs/coding-standard": "^4.1",
-        "symfony/browser-kit": "^4.4 || ^5.4 || ^6.0",
-        "symfony/debug-bundle": "^4.4 || ^5.4 || ^6.0",
-        "symfony/dotenv": "^4.4 || ^5.4 || ^6.0",
-        "symfony/intl": "^4.4 || ^5.4 || ^6.0",
-        "symfony/web-profiler-bundle": "^4.4 || ^5.4 || ^6.0"
+        "symfony/browser-kit": "^5.4 || ^6.0",
+        "symfony/debug-bundle": "^5.4 || ^6.0",
+        "symfony/dotenv": "^5.4 || ^6.0",
+        "symfony/intl": "^5.4 || ^6.0",
+        "symfony/web-profiler-bundle": "^5.4 || ^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.4 || ^8.0",
-        "guzzlehttp/psr7": "^1.7",
+        "ext-json": "*",
         "http-interop/http-factory-guzzle": "^1.0",
         "php-http/guzzle6-adapter": "^2.0",
         "php-http/httplug": "^2.0",
@@ -25,12 +25,12 @@
         "dmore/chrome-mink-driver": "^2.7",
         "friends-of-behat/mink": "^1.8",
         "friends-of-behat/mink-browserkit-driver": "^1.4",
+        "friends-of-behat/mink-debug-extension": "^2.1.0",
         "friends-of-behat/mink-extension": "^2.4",
         "friends-of-behat/page-object-extension": "^0.3",
         "friends-of-behat/suite-settings-extension": "^1.0",
         "friends-of-behat/symfony-extension": "^2.1",
         "friends-of-behat/variadic-extension": "^1.3",
-        "friends-of-behat/mink-debug-extension": "^2.1.0",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^1.4",
         "phpstan/phpstan-doctrine": "^1.2",
@@ -43,9 +43,7 @@
         "symfony/debug-bundle": "^4.4 || ^5.4 || ^6.0",
         "symfony/dotenv": "^4.4 || ^5.4 || ^6.0",
         "symfony/intl": "^4.4 || ^5.4 || ^6.0",
-        "symfony/web-profiler-bundle": "^4.4 || ^5.4 || ^6.0",
-        "symfony/web-server-bundle": "^4.4 || ^5.4 || ^6.0",
-        "vimeo/psalm": "3.11.4"
+        "symfony/web-profiler-bundle": "^4.4 || ^5.4 || ^6.0"
     },
     "autoload": {
         "psr-4": {
@@ -61,9 +59,10 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "symfony/thanks": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "phpstan/extension-installer": true
+            "php-http/discovery": true,
+            "phpstan/extension-installer": true,
+            "symfony/thanks": true
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "symfony/lock": "^6.4",
         "symfony/messenger": "^5.4 || ^6.0",
         "symfony/property-info": "^5.4 || ^6.0",
-        "symfony/serializer": "^5.4 || >=6.0 <6.4"
+        "symfony/serializer": "^5.4 || ^6.0"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",
@@ -41,7 +41,8 @@
         "symfony/debug-bundle": "^5.4 || ^6.0",
         "symfony/dotenv": "^5.4 || ^6.0",
         "symfony/intl": "^5.4 || ^6.0",
-        "symfony/web-profiler-bundle": "^5.4 || ^6.0"
+        "symfony/web-profiler-bundle": "^5.4 || ^6.0",
+        "vimeo/psalm": "^6.0"
     },
     "autoload": {
         "psr-4": {
@@ -62,6 +63,9 @@
             "phpstan/extension-installer": true,
             "symfony/thanks": true
         }
+    },
+    "conflict": {
+        "symfony/serializer": "6.4.23"
     },
     "scripts": {
         "post-install-cmd": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,6 @@
 parameters:
-    phpVersion: 80300
+    phpVersion: 80100
     reportUnmatchedIgnoredErrors: false
-    checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
 
     excludePaths:
         # Makes PHPStan crash
@@ -14,6 +12,8 @@ parameters:
         - 'tests/Application/src/**.php'
 
     ignoreErrors:
+        - identifier: missingType.iterableValue
+        - identifier: missingType.generics
         - '/Parameter #1 \$configuration of method Symfony\\Component\\DependencyInjection\\Extension\\Extension::processConfiguration\(\) expects Symfony\\Component\\Config\\Definition\\ConfigurationInterface, Symfony\\Component\\Config\\Definition\\ConfigurationInterface\|null given\./'
         - '/Parameter #1 \$path of method Liip\\ImagineBundle\\Imagine\\Cache\\CacheManager::resolve\(\) expects string, string\|null given/'
         - '/Only booleans are allowed in an elseif condition, Sylius\\Component\\Core\\Model\\ImageInterface\|false given./'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 parameters:
+    phpVersion: 80300
     reportUnmatchedIgnoredErrors: false
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/10.5/phpunit.xsd"
          colors="true"
+         displayDetailsOnPhpunitDeprecations="true"
          bootstrap="tests/Application/config/bootstrap.php">
     <testsuites>
         <testsuite name="NFQSyliusOmnisendPlugin Test Suite">

--- a/src/HttpClient/ClientFactory.php
+++ b/src/HttpClient/ClientFactory.php
@@ -17,28 +17,27 @@ use Http\Client\Common\Plugin\BaseUriPlugin;
 use Http\Client\Common\Plugin\ErrorPlugin;
 use Http\Client\Common\Plugin\HeaderDefaultsPlugin;
 use Http\Client\Common\PluginClient;
-use Http\Client\HttpClient;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\UriFactoryDiscovery;
 use NFQ\SyliusOmnisendPlugin\Model\ChannelOmnisendTrackingAwareInterface;
+use Psr\Http\Client\ClientInterface;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 
 class ClientFactory implements ClientFactoryInterface
 {
     public const ENDPOINT = 'https://api.omnisend.com/';
 
-    /** @var ChannelRepositoryInterface */
-    private $channelRepository;
+    private ChannelRepositoryInterface $channelRepository;
 
     public function __construct(ChannelRepositoryInterface $channelRepository)
     {
         $this->channelRepository = $channelRepository;
     }
 
-    public function create(?string $channelCode): HttpClient
+    public function create(?string $channelCode): ClientInterface
     {
         $channel = null;
-        if (null !== $channelCode) {
+        if ($channelCode !== null) {
             /** @var ChannelOmnisendTrackingAwareInterface $channel */
             $channel = $this->channelRepository->findOneByCode($channelCode);
         }
@@ -48,7 +47,7 @@ class ClientFactory implements ClientFactoryInterface
             [
                 'Content-Type' => 'application/json',
                 'X-API-KEY' => $channel !== null ? $channel->getOmnisendApiKey() : null,
-            ]
+            ],
         );
 
         $plugins = [

--- a/src/HttpClient/ClientFactoryInterface.php
+++ b/src/HttpClient/ClientFactoryInterface.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace NFQ\SyliusOmnisendPlugin\HttpClient;
 
-use Http\Client\HttpClient;
+use Psr\Http\Client\ClientInterface;
 
 interface ClientFactoryInterface
 {
-    public function create(?string $channelCode): HttpClient;
+    public function create(?string $channelCode): ClientInterface;
 }

--- a/src/Resources/config/services/builders.yaml
+++ b/src/Resources/config/services/builders.yaml
@@ -12,7 +12,7 @@ services:
   nfq_sylius_omnisend_plugin.builder.product_picker_director:
     class: NFQ\SyliusOmnisendPlugin\Builder\ProductPickerBuilderDirector
     arguments:
-      - '@sylius.product_variant_resolver.default'
+      - '@Sylius\Component\Product\Resolver\ProductVariantResolverInterface'
       - '@nfq_sylius_omnisend_plugin.builder.product_picker'
 
   nfq_sylius_omnisend_plugin.builder.request.contact:

--- a/tests/Application/.env
+++ b/tests/Application/.env
@@ -20,10 +20,3 @@ JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
 JWT_PASSPHRASE=acme_plugin_development
 ###< lexik/jwt-authentication-bundle ###
-
-###> symfony/swiftmailer-bundle ###
-# For Gmail as a transport, use: "gmail://username:password@localhost"
-# For a generic SMTP server, use: "smtp://localhost:25?encryption=&auth_mode="
-# Delivery is disabled by default via "null://localhost"
-MAILER_URL=smtp://localhost
-###< symfony/swiftmailer-bundle ###

--- a/tests/Application/Kernel.php
+++ b/tests/Application/Kernel.php
@@ -10,53 +10,24 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
-use Symfony\Component\Routing\RouteCollectionBuilder;
 
 final class Kernel extends BaseKernel
 {
-    use MicroKernelTrait;
-
     private const CONFIG_EXTS = '.{php,xml,yaml,yml}';
 
-    public function getCacheDir(): string
-    {
-        return $this->getProjectDir() . '/var/cache/' . $this->environment;
-    }
+    use MicroKernelTrait;
 
-    public function getLogDir(): string
+    /** @noinspection PhpUnusedPrivateMethodInspection */
+    private function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
-        return $this->getProjectDir() . '/var/log';
-    }
-
-    public function registerBundles(): iterable
-    {
-        $contents = require $this->getProjectDir() . '/config/bundles.php';
-        foreach ($contents as $class => $envs) {
-            if (isset($envs['all']) || isset($envs[$this->environment])) {
-                yield new $class();
-            }
-        }
-    }
-
-    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
-    {
-        $container->addResource(new FileResource($this->getProjectDir() . '/config/bundles.php'));
+        $container->addResource(new FileResource($this->getBundlesPath()));
         $container->setParameter('container.dumper.inline_class_loader', true);
-        $confDir = $this->getProjectDir() . '/config';
+        $confDir = $this->getConfigDir();
 
         $loader->load($confDir . '/{packages}/*' . self::CONFIG_EXTS, 'glob');
         $loader->load($confDir . '/{packages}/' . $this->environment . '/**/*' . self::CONFIG_EXTS, 'glob');
         $loader->load($confDir . '/{services}' . self::CONFIG_EXTS, 'glob');
         $loader->load($confDir . '/{services}_' . $this->environment . self::CONFIG_EXTS, 'glob');
-    }
-
-    protected function configureRoutes(RouteCollectionBuilder $routes): void
-    {
-        $confDir = $this->getProjectDir() . '/config';
-
-        $routes->import($confDir . '/{routes}/*' . self::CONFIG_EXTS, '/', 'glob');
-        $routes->import($confDir . '/{routes}/' . $this->environment . '/**/*' . self::CONFIG_EXTS, '/', 'glob');
-        $routes->import($confDir . '/{routes}' . self::CONFIG_EXTS, '/', 'glob');
     }
 
     protected function getContainerBaseClass(): string
@@ -70,6 +41,6 @@ final class Kernel extends BaseKernel
 
     private function isTestEnvironment(): bool
     {
-        return 0 === strpos($this->getEnvironment(), 'test');
+        return strpos($this->getEnvironment(), 'test') === 0;
     }
 }

--- a/tests/Application/config/bootstrap.php
+++ b/tests/Application/config/bootstrap.php
@@ -15,7 +15,7 @@ if (is_array($env = @include dirname(__DIR__) . '/.env.local.php')) {
     throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
 } else {
     // load all the .env files
-    (new Dotenv(true))->loadEnv(dirname(__DIR__) . '/.env');
+    (new Dotenv())->loadEnv(dirname(__DIR__) . '/.env');
 }
 
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';

--- a/tests/Application/config/bundles.php
+++ b/tests/Application/config/bundles.php
@@ -1,12 +1,15 @@
 <?php
 
+use Sylius\Abstraction\StateMachine\SyliusStateMachineAbstractionBundle;
+use Symfony\WebpackEncoreBundle\WebpackEncoreBundle;
+
 $bundles = [
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
-    Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle::class => ['all' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
+    SyliusStateMachineAbstractionBundle::class => ['all' => true],
     Sylius\Bundle\OrderBundle\SyliusOrderBundle::class => ['all' => true],
     Sylius\Bundle\MoneyBundle\SyliusMoneyBundle::class => ['all' => true],
     Sylius\Bundle\CurrencyBundle\SyliusCurrencyBundle::class => ['all' => true],
@@ -46,7 +49,6 @@ $bundles = [
     Sylius\Bundle\ThemeBundle\SyliusThemeBundle::class => ['all' => true],
     Sylius\Bundle\AdminBundle\SyliusAdminBundle::class => ['all' => true],
     Sylius\Bundle\ShopBundle\SyliusShopBundle::class => ['all' => true],
-    NFQ\SyliusOmnisendPlugin\NFQSyliusOmnisendPlugin::class => ['all' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true, 'test_cached' => true],
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true, 'test_cached' => true],
     FriendsOfBehat\SymfonyExtension\Bundle\FriendsOfBehatSymfonyExtensionBundle::class => ['test' => true, 'test_cached' => true],
@@ -56,6 +58,10 @@ $bundles = [
     Sylius\Bundle\ApiBundle\SyliusApiBundle::class => ['all' => true],
     SyliusLabs\DoctrineMigrationsExtraBundle\SyliusLabsDoctrineMigrationsExtraBundle::class => ['all' => true],
     Http\HttplugBundle\HttplugBundle::class => ['all' => true],
+    League\FlysystemBundle\FlysystemBundle::class => ['all' => true],
+    WebpackEncoreBundle::class => ['all' => true],
+
+    NFQ\SyliusOmnisendPlugin\NFQSyliusOmnisendPlugin::class => ['all' => true],
 ];
 
 // Sylius 1.11 and above

--- a/tests/Application/config/bundles.php
+++ b/tests/Application/config/bundles.php
@@ -44,7 +44,6 @@ $bundles = [
     Sylius\Bundle\FixturesBundle\SyliusFixturesBundle::class => ['all' => true],
     Sylius\Bundle\PayumBundle\SyliusPayumBundle::class => ['all' => true],
     Sylius\Bundle\ThemeBundle\SyliusThemeBundle::class => ['all' => true],
-    Symfony\Bundle\WebServerBundle\WebServerBundle::class => ['all' => true],
     Sylius\Bundle\AdminBundle\SyliusAdminBundle::class => ['all' => true],
     Sylius\Bundle\ShopBundle\SyliusShopBundle::class => ['all' => true],
     NFQ\SyliusOmnisendPlugin\NFQSyliusOmnisendPlugin::class => ['all' => true],

--- a/tests/Application/config/packages/dev/jms_serializer.yaml
+++ b/tests/Application/config/packages/dev/jms_serializer.yaml
@@ -1,6 +1,6 @@
 jms_serializer:
     visitors:
-        json:
+        json_serialization:
             options:
                 - JSON_PRETTY_PRINT
                 - JSON_UNESCAPED_SLASHES

--- a/tests/Application/config/packages/dev/swiftmailer.yaml
+++ b/tests/Application/config/packages/dev/swiftmailer.yaml
@@ -1,2 +1,0 @@
-swiftmailer:
-    disable_delivery: true

--- a/tests/Application/config/packages/dev/web_profiler.yaml
+++ b/tests/Application/config/packages/dev/web_profiler.yaml
@@ -1,3 +1,4 @@
 web_profiler:
+#    profiling: true
     toolbar: true
     intercept_redirects: false

--- a/tests/Application/config/packages/httplug.yaml
+++ b/tests/Application/config/packages/httplug.yaml
@@ -1,2 +1,0 @@
-imports:
-  - { resource: "@NFQSyliusOmnisendPlugin/Resources/config/httplug.yaml" }

--- a/tests/Application/config/packages/prod/jms_serializer.yaml
+++ b/tests/Application/config/packages/prod/jms_serializer.yaml
@@ -1,6 +1,6 @@
 jms_serializer:
     visitors:
-        json:
+        json_serialization:
             options:
                 - JSON_UNESCAPED_SLASHES
                 - JSON_PRESERVE_ZERO_FRACTION

--- a/tests/Application/config/packages/security.yaml
+++ b/tests/Application/config/packages/security.yaml
@@ -5,7 +5,7 @@ parameters:
     sylius.security.new_api_regex: "^%sylius.security.new_api_route%"
 
 security:
-    always_authenticate_before_granting: true
+    enable_authenticator_manager: true
     providers:
         sylius_admin_user_provider:
             id: sylius.admin_user_provider.email_or_name_based
@@ -19,8 +19,9 @@ security:
             chain:
                 providers: [sylius_api_shop_user_provider, sylius_api_admin_user_provider]
 
-    encoders:
+    password_hashers:
         Sylius\Component\User\Model\UserInterface: argon2i
+
     firewalls:
         admin:
             switch_user: true
@@ -35,7 +36,7 @@ security:
                 default_target_path: sylius_admin_dashboard
                 use_forward: false
                 use_referer: true
-                csrf_token_generator: security.csrf.token_manager
+                enable_csrf: true
                 csrf_parameter: _csrf_admin_security_token
                 csrf_token_id: admin_authenticate
             remember_me:
@@ -47,46 +48,35 @@ security:
             logout:
                 path: sylius_admin_logout
                 target: sylius_admin_login
-            anonymous: true
 
         new_api_admin_user:
-            pattern: "%sylius.security.new_api_route%/admin-user-authentication-token"
+            pattern: "%sylius.security.new_api_admin_route%/administrators/token"
             provider: sylius_admin_user_provider
             stateless: true
-            anonymous: true
+            entry_point: jwt
             json_login:
-                check_path: "%sylius.security.new_api_route%/admin-user-authentication-token"
+                check_path: "%sylius.security.new_api_admin_route%/administrators/token"
                 username_path: email
                 password_path: password
-                success_handler: lexik_jwt_authentication.handler.authentication_success
-                failure_handler: lexik_jwt_authentication.handler.authentication_failure
-            guard:
-                authenticators:
-                    - lexik_jwt_authentication.jwt_token_authenticator
+            jwt: true
 
         new_api_shop_user:
-            pattern: "%sylius.security.new_api_route%/shop-user-authentication-token"
+            pattern: "%sylius.security.new_api_shop_route%/customers/token"
             provider: sylius_shop_user_provider
             stateless: true
-            anonymous: true
+            entry_point: jwt
             json_login:
-                check_path: "%sylius.security.new_api_route%/shop-user-authentication-token"
+                check_path: "%sylius.security.new_api_shop_route%/customers/token"
                 username_path: email
                 password_path: password
-                success_handler: lexik_jwt_authentication.handler.authentication_success
-                failure_handler: lexik_jwt_authentication.handler.authentication_failure
-            guard:
-                authenticators:
-                    - lexik_jwt_authentication.jwt_token_authenticator
+            jwt: true
 
         new_api:
             pattern: "%sylius.security.new_api_regex%/*"
             provider: sylius_api_chain_provider
             stateless: true
-            anonymous: lazy
-            guard:
-                authenticators:
-                    - lexik_jwt_authentication.jwt_token_authenticator
+            lazy: true
+            jwt: true
 
         shop:
             switch_user: { role: ROLE_ALLOWED_TO_SWITCH }
@@ -94,8 +84,6 @@ security:
             pattern: "%sylius.security.shop_regex%"
             provider: sylius_shop_user_provider
             form_login:
-                success_handler: sylius.authentication.success_handler
-                failure_handler: sylius.authentication.failure_handler
                 provider: sylius_shop_user_provider
                 login_path: sylius_shop_login
                 check_path: sylius_shop_login_check
@@ -103,7 +91,6 @@ security:
                 default_target_path: sylius_shop_homepage
                 use_forward: false
                 use_referer: true
-                csrf_token_generator: security.csrf.token_manager
                 csrf_parameter: _csrf_shop_security_token
                 csrf_token_id: shop_authenticate
             remember_me:
@@ -113,10 +100,8 @@ security:
                 remember_me_parameter: _remember_me
             logout:
                 path: sylius_shop_logout
-                target: sylius_shop_login
+                target: sylius_shop_homepage
                 invalidate_session: false
-                success_handler: sylius.handler.shop_user_logout
-            anonymous: true
 
         dev:
             pattern:  ^/(_(profiler|wdt)|css|images|js)/
@@ -135,4 +120,5 @@ security:
         - { path: "%sylius.security.shop_regex%/verify", role: IS_AUTHENTICATED_ANONYMOUSLY }
 
         - { path: "%sylius.security.admin_regex%", role: ROLE_ADMINISTRATION_ACCESS }
+        - { path: "%sylius.security.admin_regex%/forgotten-password", role: PUBLIC_ACCESS }
         - { path: "%sylius.security.shop_regex%/account", role: ROLE_USER }

--- a/tests/Application/config/packages/staging/swiftmailer.yaml
+++ b/tests/Application/config/packages/staging/swiftmailer.yaml
@@ -1,2 +1,0 @@
-swiftmailer:
-    disable_delivery: true

--- a/tests/Application/config/packages/swiftmailer.yaml
+++ b/tests/Application/config/packages/swiftmailer.yaml
@@ -1,2 +1,0 @@
-swiftmailer:
-    url: '%env(MAILER_URL)%'

--- a/tests/Application/config/packages/test/mailer.yaml
+++ b/tests/Application/config/packages/test/mailer.yaml
@@ -1,0 +1,7 @@
+framework:
+  mailer:
+    dsn: 'null://null'
+  cache:
+    pools:
+      test.mailer_pool:
+        adapter: cache.adapter.filesystem

--- a/tests/Application/config/packages/test/security.yaml
+++ b/tests/Application/config/packages/test/security.yaml
@@ -1,3 +1,3 @@
 security:
-    encoders:
+    password_hashers:
         sha512: sha512

--- a/tests/Application/config/packages/test/swiftmailer.yaml
+++ b/tests/Application/config/packages/test/swiftmailer.yaml
@@ -1,6 +1,0 @@
-swiftmailer:
-    disable_delivery: true
-    logging: true
-    spool:
-        type: file
-        path: "%kernel.cache_dir%/spool"

--- a/tests/Application/config/packages/test/web_profiler.yaml
+++ b/tests/Application/config/packages/test/web_profiler.yaml
@@ -1,4 +1,5 @@
 web_profiler:
+#    profiling: false
     toolbar: false
     intercept_redirects: false
 

--- a/tests/Application/config/packages/test_cached/security.yaml
+++ b/tests/Application/config/packages/test_cached/security.yaml
@@ -1,3 +1,3 @@
 security:
-    encoders:
+    password_hashers:
         sha512: sha512

--- a/tests/Application/config/packages/test_cached/swiftmailer.yaml
+++ b/tests/Application/config/packages/test_cached/swiftmailer.yaml
@@ -1,6 +1,0 @@
-swiftmailer:
-    disable_delivery: true
-    logging: true
-    spool:
-        type: file
-        path: "%kernel.cache_dir%/spool"

--- a/tests/Application/config/routes/liip_imagine.yaml
+++ b/tests/Application/config/routes/liip_imagine.yaml
@@ -1,2 +1,2 @@
-_liip_imagine:
+liip_imagine:
     resource: "@LiipImagineBundle/Resources/config/routing.yaml"

--- a/tests/Behat/Mock/ClientFactoryMock.php
+++ b/tests/Behat/Mock/ClientFactoryMock.php
@@ -13,20 +13,19 @@ declare(strict_types=1);
 
 namespace Tests\NFQ\SyliusOmnisendPlugin\Behat\Mock;
 
-use Http\Client\HttpClient;
 use NFQ\SyliusOmnisendPlugin\HttpClient\ClientFactoryInterface;
+use Psr\Http\Client\ClientInterface;
 
 class ClientFactoryMock implements ClientFactoryInterface
 {
-    /** @var LoggableClientMock */
-    private $loggableClientMock;
+    private LoggableClientMock $loggableClientMock;
 
     public function __construct(LoggableClientMock $loggableClientMock)
     {
         $this->loggableClientMock = $loggableClientMock;
     }
 
-    public function create(?string $channelCode): HttpClient
+    public function create(?string $channelCode): ClientInterface
     {
         return $this->loggableClientMock;
     }

--- a/tests/Behat/Mock/OmnisendClientMock.php
+++ b/tests/Behat/Mock/OmnisendClientMock.php
@@ -170,7 +170,7 @@ class OmnisendClientMock implements OmnisendClientInterface
     public function postEvent(CreateEvent $event, ?string $channelCode): ?object
     {
         $this->client->postEvent($event, $channelCode);
-        return (new EventSuccess());
+        return new EventSuccess();
     }
 
     public function getContactByPhone(?string $phone, ?string $channelCode): ?object
@@ -202,5 +202,14 @@ class OmnisendClientMock implements OmnisendClientInterface
         return [
             $event
         ];
+    }
+
+    public function getBatch(string $batchId, ?string $channelCode): ?object
+    {
+        $this->client->getBatch($batchId, $channelCode);
+        $batch = new BatchSuccess();
+        $batch->setBatchID($batchId);
+
+        return $batch;
     }
 }

--- a/tests/Behat/Resources/suites.yml
+++ b/tests/Behat/Resources/suites.yml
@@ -36,7 +36,8 @@ default:
                 - nfq_sylius_omnisend.context.hook.doctrine
                 - nfq_sylius_omnisend.context.hook.client_request
                 - sylius.behat.context.hook.doctrine_orm
-                - sylius.behat.context.hook.email_spool
+                - sylius.behat.context.hook.mailer
+                - sylius.behat.context.hook.session
 
                 - sylius.behat.context.transform.customer
                 - sylius.behat.context.transform.locale
@@ -131,7 +132,8 @@ default:
                 - nfq_sylius_omnisend.context.client_request
                 - nfq_sylius_omnisend.context.ui.shop.cart
                 - sylius.behat.context.hook.doctrine_orm
-                - sylius.behat.context.hook.email_spool
+                - sylius.behat.context.hook.mailer
+                - sylius.behat.context.hook.session
 
                 - sylius.behat.context.transform.address
                 - sylius.behat.context.transform.country

--- a/tests/Builder/Request/OrderBuilderTest.php
+++ b/tests/Builder/Request/OrderBuilderTest.php
@@ -20,7 +20,9 @@ use NFQ\SyliusOmnisendPlugin\Factory\Request\OrderProductFactoryInterface;
 use NFQ\SyliusOmnisendPlugin\Mapper\OrderPaymentStateMapper;
 use NFQ\SyliusOmnisendPlugin\Mapper\OrderStateMapper;
 use NFQ\SyliusOmnisendPlugin\Resolver\DefaultOrderCourierDataResolver;
+use NFQ\SyliusOmnisendPlugin\Resolver\OrderAdditionalDataResolverInterface;
 use NFQ\SyliusOmnisendPlugin\Resolver\OrderCouponResolverInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\Customer;
@@ -39,26 +41,28 @@ use Tests\NFQ\SyliusOmnisendPlugin\Mock\OrderMock;
 
 class OrderBuilderTest extends TestCase
 {
-    /** @var OrderBuilderInterface */
-    private $builder;
+    private OrderBuilderInterface $builder;
 
-    /** @var OrderAddressFactoryInterface */
-    private $addressFactory;
+    /** @var OrderAddressFactoryInterface & MockObject */
+    private OrderAddressFactoryInterface $addressFactory;
 
-    /** @var OrderProductFactoryInterface */
-    private $orderProductFactory;
+    /** @var OrderProductFactoryInterface & MockObject */
+    private OrderProductFactoryInterface $orderProductFactory;
 
-    /** @var OrderStateMapper */
-    private $stateMapper;
+    /** @var OrderStateMapper & MockObject */
+    private OrderStateMapper $stateMapper;
 
-    /** @var OrderPaymentStateMapper */
-    private $paymentStateMapper;
+    /** @var OrderPaymentStateMapper & MockObject */
+    private OrderPaymentStateMapper $paymentStateMapper;
 
-    /** @var OrderCouponResolverInterface */
-    private $orderCouponResolver;
+    /** @var OrderCouponResolverInterface & MockObject */
+    private OrderCouponResolverInterface $orderCouponResolver;
 
-    /** @var RouterInterface */
-    private $router;
+    /** @var RouterInterface & MockObject */
+    private RouterInterface $router;
+
+    /** @var OrderAdditionalDataResolverInterface & MockObject */
+    private OrderAdditionalDataResolverInterface $orderAdditionalDataResolver;
 
     protected function setUp(): void
     {
@@ -68,6 +72,7 @@ class OrderBuilderTest extends TestCase
         $this->paymentStateMapper = $this->createMock(OrderPaymentStateMapper::class);
         $this->orderCouponResolver = $this->createMock(OrderCouponResolverInterface::class);
         $this->router = $this->createMock(RouterInterface::class);
+        $this->orderAdditionalDataResolver = $this->createMock(OrderAdditionalDataResolverInterface::class);
         $this->builder = new OrderBuilder(
             $this->addressFactory,
             $this->orderProductFactory,
@@ -75,11 +80,12 @@ class OrderBuilderTest extends TestCase
             $this->paymentStateMapper,
             $this->orderCouponResolver,
             new DefaultOrderCourierDataResolver(),
+            $this->orderAdditionalDataResolver,
             $this->router
         );
     }
 
-    public function testIfBuildsOrderData()
+    public function testIfBuildsOrderData(): void
     {
         $order = new Order();
         $order->setLocaleCode('en');
@@ -125,7 +131,7 @@ class OrderBuilderTest extends TestCase
         $this->assertEquals('shippingMethodTrans', $result->getShippingMethod());
     }
 
-    public function testIfBuildsOrderTotals()
+    public function testIfBuildsOrderTotals(): void
     {
         $order = new OrderMock();
         $order->setCurrencyCode('EUR');

--- a/tests/Factory/Request/CartProductFactoryTest.php
+++ b/tests/Factory/Request/CartProductFactoryTest.php
@@ -50,27 +50,32 @@ class CartProductFactoryTest extends TestCase
         );
     }
 
-    public function testIfCreatesWell()
+    public function testIfCreatesWell(): void
     {
         $order = new Order();
         $order->setLocaleCode('en');
         $orderItem = new OrderItem();
         $orderItem->setOrder($order);
         $orderItem->setUnitPrice(5000);
-        $orderItem->addUnit(new OrderItemUnit($orderItem));
+
+        $itemUnit = new OrderItemUnit($orderItem);
+        $orderItem->addUnit($itemUnit);
         $orderItem->setProductName('Name');
         $adjustment1 = new Adjustment();
         $adjustment1->setAmount(-1000);
-        $adjustment1->setType(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT);
-        $orderItem->addAdjustment($adjustment1);
-        $variant = new ProductVariant();
-        $product = new Product();
+        $adjustment1->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
+        $itemUnit->addAdjustment($adjustment1);
+
         $productTranslation = new ProductTranslation();
         $productTranslation->setLocale('en');
         $productTranslation->setSlug('product');
+
+        $product = new Product();
         $product->addTranslation($productTranslation);
-        $variant->setProduct($product);
         $product->setCode('product_code');
+
+        $variant = new ProductVariant();
+        $variant->setProduct($product);
         $variant->setCode('variant_code');
         $orderItem->setVariant($variant);
         $this->productUrlResolver
@@ -85,14 +90,14 @@ class CartProductFactoryTest extends TestCase
 
         $product = $this->factory->create($orderItem);
 
-        $this->assertEquals($product->getTitle(), 'Name');
-        $this->assertEquals($product->getProductUrl(), 'url');
-        $this->assertEquals($product->getImageUrl(), 'test.jpg');
-        $this->assertEquals($product->getPrice(), 4000);
-        $this->assertEquals($product->getOldPrice(), 5000);
-        $this->assertEquals($product->getQuantity(), 1);
-        $this->assertEquals($product->getDiscount(), 1000);
-        $this->assertEquals($product->getSku(), 'product_code');
-        $this->assertEquals($product->getVariantID(), 'variant_code');
+        $this->assertEquals('Name', $product->getTitle());
+        $this->assertEquals('url', $product->getProductUrl());
+        $this->assertEquals('test.jpg', $product->getImageUrl());
+        $this->assertEquals(4000, $product->getPrice());
+        $this->assertEquals(5000, $product->getOldPrice());
+        $this->assertEquals(1, $product->getQuantity());
+        $this->assertEquals(1000, $product->getDiscount());
+        $this->assertEquals('product_code', $product->getSku());
+        $this->assertEquals('variant_code', $product->getVariantID());
     }
 }

--- a/tests/Factory/Request/ContactIdentifierFactoryTest.php
+++ b/tests/Factory/Request/ContactIdentifierFactoryTest.php
@@ -45,7 +45,7 @@ class ContactIdentifierFactoryTest extends TestCase
         $this->assertEquals($identifier, $result);
     }
 
-    public function data()
+    public static function data()
     {
         $date = new DateTime('2012-12-12 12:12:12');
         DatetimeProvider::setDateTime($date);

--- a/tests/Factory/Request/OrderProductFactoryTest.php
+++ b/tests/Factory/Request/OrderProductFactoryTest.php
@@ -81,14 +81,15 @@ class OrderProductFactoryTest extends TestCase
 
         $adjustment = new Adjustment();
         $adjustment->setAmount(-1000);
-        $adjustment->setType(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT);
+        $adjustment->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
 
         $orderItem = new OrderItem();
         $orderItem->setOrder($order);
         $orderItem->setUnitPrice(5000);
-        $orderItem->addUnit(new OrderItemUnit($orderItem));
+        $itemUnit = new OrderItemUnit($orderItem);
+        $itemUnit->addAdjustment($adjustment);
+        $orderItem->addUnit($itemUnit);
         $orderItem->setProductName('Name');
-        $orderItem->addAdjustment($adjustment);
         $orderItem->setVariant($variant);
 
         $this->productUrlResolver

--- a/tests/Functional/CartRequestTest.php
+++ b/tests/Functional/CartRequestTest.php
@@ -65,7 +65,7 @@ class CartRequestTest extends WebTestCase
         );
     }
 
-    public function data(): array
+    public static function data(): array
     {
         $order = new OrderMock();
         $order->setCurrencyCode('EUR');
@@ -124,7 +124,7 @@ class CartRequestTest extends WebTestCase
                   ]
                 }
             JSON,
-            ],
-        ];
-    }
+                    ],
+                ];
+            }
 }

--- a/tests/Functional/CartRequestTest.php
+++ b/tests/Functional/CartRequestTest.php
@@ -39,21 +39,19 @@ class CartRequestTest extends WebTestCase
 {
     use PHPMatcherAssertions;
 
-    /** @var SerializerInterface */
-    private $serializer;
+    private SerializerInterface $serializer;
 
-    /** @var CartBuilderDirectorInterface */
-    private $director;
+    private CartBuilderDirectorInterface $director;
 
     protected function setUp(): void
     {
         self::bootKernel();
-        $this->serializer = self::$container->get('serializer');
-        $this->director = self::$container->get('nfq_sylius_omnisend_plugin.builder.request.cart_director');
+        $this->serializer = self::getContainer()->get('serializer');
+        $this->director = self::getContainer()->get('nfq_sylius_omnisend_plugin.builder.request.cart_director');
     }
 
     /** @dataProvider data */
-    public function testIfFormatValidRequest(OrderMock $data, string $result)
+    public function testIfFormatValidRequest(OrderMock $data, string $result): void
     {
         $this->assertMatchesPattern(
             $result,
@@ -75,12 +73,13 @@ class CartRequestTest extends WebTestCase
         $orderItem = new OrderItem();
         $orderItem->setOrder($order);
         $orderItem->setUnitPrice(5000);
-        $orderItem->addUnit(new OrderItemUnit($orderItem));
+        $itemUnit = new OrderItemUnit($orderItem);
+        $orderItem->addUnit($itemUnit);
         $orderItem->setProductName('Name');
         $adjustment1 = new Adjustment();
         $adjustment1->setAmount(-1000);
-        $adjustment1->setType(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT);
-        $orderItem->addAdjustment($adjustment1);
+        $adjustment1->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
+        $itemUnit->addAdjustment($adjustment1);
         $variant = new ProductVariant();
         $product = new Product();
         $productTranslation = new ProductTranslation();

--- a/tests/Functional/CategoryRequestTest.php
+++ b/tests/Functional/CategoryRequestTest.php
@@ -56,7 +56,7 @@ class CategoryRequestTest extends WebTestCase
         );
     }
 
-    public function data(): array
+    public static function data(): array
     {
         $taxon = new Taxon();
         $taxonTranslation = new TaxonTranslation();
@@ -77,7 +77,7 @@ class CategoryRequestTest extends WebTestCase
                   "createdAt": "@string@"
                 }
             JSON,
-            ],
-        ];
-    }
+                    ],
+                ];
+            }
 }

--- a/tests/Functional/ContactRequestTest.php
+++ b/tests/Functional/ContactRequestTest.php
@@ -53,7 +53,7 @@ class ContactRequestTest extends WebTestCase
         );
     }
 
-    public function data(): array
+    public static function data(): array
     {
         $customer1 = new Customer();
         $customer1->setEmail('test@nfq.lt');
@@ -98,10 +98,10 @@ class ContactRequestTest extends WebTestCase
                   "createdAt": "@string@"
                 }
             JSON,
-            ],
-            'onlyPhone' => [
-                $customer2,
-                <<<JSON
+                    ],
+                    'onlyPhone' => [
+                        $customer2,
+                        <<<JSON
                 {
                   "identifiers": [
                     {
@@ -120,9 +120,9 @@ class ContactRequestTest extends WebTestCase
                 }
             JSON
             ],
-            'full' => [
-                $customer3,
-                <<<JSON
+                    'full' => [
+                        $customer3,
+                        <<<JSON
                 {
                    "identifiers": [
                     {
@@ -161,6 +161,6 @@ class ContactRequestTest extends WebTestCase
                 }
             JSON
             ],
-        ];
-    }
+                ];
+            }
 }

--- a/tests/Functional/OrderRequestTest.php
+++ b/tests/Functional/OrderRequestTest.php
@@ -72,7 +72,7 @@ class OrderRequestTest extends WebTestCase
         );
     }
 
-    public function data(): array
+    public static function data(): array
     {
         $order = new OrderMock();
         $order->setLocaleCode('en');
@@ -237,7 +237,7 @@ class OrderRequestTest extends WebTestCase
                   "cartID": "@string@"
                 }
             JSON,
-            ],
-        ];
-    }
+                    ],
+                ];
+            }
 }

--- a/tests/Functional/OrderRequestTest.php
+++ b/tests/Functional/OrderRequestTest.php
@@ -14,9 +14,12 @@ declare(strict_types=1);
 namespace Tests\NFQ\SyliusOmnisendPlugin\Functional;
 
 use Coduo\PHPMatcher\PHPUnit\PHPMatcherAssertions;
+use DateTime;
 use NFQ\SyliusOmnisendPlugin\Builder\Request\OrderBuilderDirectorInterface;
+use NFQ\SyliusOmnisendPlugin\Model\OrderDetails;
 use Sylius\Component\Core\Model\Address;
 use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\Customer;
 use Sylius\Component\Core\Model\OrderItem;
 use Sylius\Component\Core\Model\OrderItemUnit;
 use Sylius\Component\Core\Model\Payment;
@@ -50,8 +53,8 @@ class OrderRequestTest extends WebTestCase
     protected function setUp(): void
     {
         self::bootKernel();
-        $this->serializer = self::$container->get('serializer');
-        $this->director = self::$container->get('nfq_sylius_omnisend_plugin.builder.request.order_director');
+        $this->serializer = self::getContainer()->get('serializer');
+        $this->director = self::getContainer()->get('nfq_sylius_omnisend_plugin.builder.request.order_director');
     }
 
     /** @dataProvider data */
@@ -74,10 +77,12 @@ class OrderRequestTest extends WebTestCase
         $order = new OrderMock();
         $order->setLocaleCode('en');
         $order->setNumber('R0011');
-        $order->setCreatedAt(new \DateTime('2012-02-12 12:12:12'));
-        $order->setUpdatedAt(new \DateTime('2012-02-12 12:12:12'));
-        $order->getOmnisendOrderDetails()->setCartId('111');
-        $order->getOmnisendOrderDetails()->setCancelledAt(new \DateTime('2012-02-12 12:12:12'));
+        $order->setCreatedAt(new DateTime('2012-02-12 12:12:12'));
+        $order->setUpdatedAt(new DateTime('2012-02-12 12:12:12'));
+        $orderDetails = $order->getOmnisendOrderDetails();
+        $orderDetails->setCartId('111');
+        $orderDetails->setCancelledAt(new DateTime('2012-02-12 12:12:12'));
+        $orderDetails->setOrder($order);
         $payment = new Payment();
         $paymentMethod = new PaymentMethod();
         $paymentMethodTrans = new PaymentMethodTranslation();
@@ -98,7 +103,7 @@ class OrderRequestTest extends WebTestCase
         $shipping->setMethod($shippingMethod);
         $order->addShipment($shipping);
 
-        $customer = new \Sylius\Component\Core\Model\Customer();
+        $customer = new Customer();
         $customer->setEmail('test@nfq.lt');
 
         $order->setCustomer($customer);

--- a/tests/Mapper/OrderPaymentStateMapperTest.php
+++ b/tests/Mapper/OrderPaymentStateMapperTest.php
@@ -36,7 +36,7 @@ class OrderPaymentStateMapperTest extends TestCase
         $this->assertEquals($mapper->getState($order), $toState);
     }
 
-    public function data()
+    public static function data()
     {
         return [
             'STATE_CART' => [

--- a/tests/Mapper/OrderStateMapperTest.php
+++ b/tests/Mapper/OrderStateMapperTest.php
@@ -36,7 +36,7 @@ class OrderStateMapperTest extends TestCase
         $this->assertEquals($mapper->getState($order), $toState);
     }
 
-    public function data()
+    public static function data()
     {
         return [
             'state_cart' => [

--- a/tests/Message/Handler/PushCategoryHandlerTest.php
+++ b/tests/Message/Handler/PushCategoryHandlerTest.php
@@ -98,7 +98,7 @@ class PushCategoryHandlerTest extends TestCase
         $this->handler->handle($message);
     }
 
-    public function data()
+    public static function data()
     {
         return [
             '0' => [

--- a/tests/Resolver/DefaultOrderCouponResolverTest.php
+++ b/tests/Resolver/DefaultOrderCouponResolverTest.php
@@ -41,7 +41,7 @@ class DefaultOrderCouponResolverTest extends TestCase
         }
     }
 
-    public function data()
+    public static function data()
     {
         $order = new Order();
         $promotionCoupon = new PromotionCoupon();

--- a/tests/Resolver/ProductAdditionalDataResolverTest.php
+++ b/tests/Resolver/ProductAdditionalDataResolverTest.php
@@ -50,7 +50,7 @@ class ProductAdditionalDataResolverTest extends TestCase
         $this->assertEquals($result, $attribute);
     }
 
-    public function attributeData()
+    public static function attributeData()
     {
         $attribute1 = new ProductAttribute();
         $attribute1->setConfiguration(['choices' => ['value' => ['en' => 'value33'], 'value2' => ['en' => 'value22']]]);

--- a/tests/Serializer/NameConverter/ProductPickerNameConverterTest.php
+++ b/tests/Serializer/NameConverter/ProductPickerNameConverterTest.php
@@ -47,7 +47,7 @@ class ProductPickerNameConverterTest extends TestCase
         $this->assertEquals($this->converter->denormalize($result), $property);
     }
 
-    public function data(): array
+    public static function data(): array
     {
         return [
             'empty string' => [

--- a/tests/Serializer/Normalizer/ProductPickerNormalizerTest.php
+++ b/tests/Serializer/Normalizer/ProductPickerNormalizerTest.php
@@ -55,7 +55,7 @@ class ProductPickerNormalizerTest extends TestCase
         $this->assertEquals($this->normalizer->supportsNormalization($normalizeData, $type), $isSupport);
     }
 
-    public function data(): array
+    public static function data(): array
     {
         return [
             'empty string' => [

--- a/tests/Utils/GenderHelperTest.php
+++ b/tests/Utils/GenderHelperTest.php
@@ -24,7 +24,7 @@ class GenderHelperTest extends TestCase
         $this->assertEquals(GenderHelper::resolve($data), $result);
     }
 
-    public function data(): array
+    public static function data(): array
     {
         return [
             'empty string' => [

--- a/tests/Utils/Order/OrderNumberResolverTest.php
+++ b/tests/Utils/Order/OrderNumberResolverTest.php
@@ -24,7 +24,7 @@ class OrderNumberResolverTest extends TestCase
         $this->assertEquals(OrderNumberResolver::resolve($data), $result);
     }
 
-    public function data()
+    public static function data()
     {
         return [
             'null' => [

--- a/tests/Validator/Constraints/CustomEventFieldsValidatorTest.php
+++ b/tests/Validator/Constraints/CustomEventFieldsValidatorTest.php
@@ -177,7 +177,7 @@ class CustomEventFieldsValidatorTest extends WebTestCase
         $this->validator->validate($data, new CustomEventFields());
     }
 
-    public function invalidFieldValues()
+    public static function invalidFieldValues()
     {
         return [
             'correctFields' =>

--- a/tests/Validator/Constraints/UniqueEventFieldValidatorTest.php
+++ b/tests/Validator/Constraints/UniqueEventFieldValidatorTest.php
@@ -59,7 +59,7 @@ class UniqueEventFieldValidatorTest extends TestCase
         $this->validator->validate($field, new UniqueEventField());
     }
 
-    public function data(): array
+    public static function data(): array
     {
         $productAttribute1 = new EventField();
         $productAttribute2 = new EventField();

--- a/tools/docker/test_unit.sh
+++ b/tools/docker/test_unit.sh
@@ -6,7 +6,7 @@ echo "PROJECT ROOT: ${PROJECT_ROOT}"
 cd "${PROJECT_ROOT}"
 
 echo "## Executing Unit Tests"
-
+rm -rf "$PROJECT_ROOT/tests/Application/var/cache/"
 ./vendor/bin/phpunit --log-junit test_unit.xml
 
 code=$?


### PR DESCRIPTION
- Remove SwiftMailer configuration and related dependencies, migrate to Symfony Mailer, and update associated services and tests.
- Removed http-interop/http-factory-guzzle and php-http/guzzle6-adapter, should not be used directly, instead httplug should be used
- Bump minimum php version to ^8.1
- update symfony/serializer requirement to ^6.4 (conflicts with 6.4.23 incompatible definition)
- bump symfony/lock requirement to 6.4+
- upgrade phpunit to 10.5
- bump sylius requirement to ~1.13
- drop support for symfony: browser-kit, debug-bundle, dotenv, intl, web-profiler-bundle, property-info, serializer, lock, messenger version 4.4
- Switch from deprecated `HttpClient` to PSR-18 `ClientInterface` for HTTP client factory
- Remove unused dependencies (`symfony/web-server-bundle`) use symfony CLI instead
- Adjust test mocks and introduced additional methods for better encapsulation and flexibility
- Clean up outdated configurations and formatting inconsistencies

```bash
PHPUnit 10.5.47 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.32
Configuration: /Users/justinas.urbanavicius/Projects/sylius-omnisend-plugin/phpunit.xml.dist

...............................................................  63 / 152 ( 41%)
............................................................... 126 / 152 ( 82%)
..........................                                      152 / 152 (100%)

Time: 00:06.531, Memory: 154.00 MB

OK (152 tests, 362 assertions)
```