### PR TITLE
Fixed logic error checking email instead of phone number

### DIFF
--- a/src/Manager/ContactManager.php
+++ b/src/Manager/ContactManager.php
@@ -78,7 +78,7 @@ class ContactManager implements ContactManagerInterface
             return $this->getFirstContact($contacts);
         }
 
-        $contacts = empty($customer->getEmail()) ? null : $this->omnisendClient->getContactByPhone(
+        $contacts = empty($customer->getPhoneNumber()) ? null : $this->omnisendClient->getContactByPhone(
             $customer->getPhoneNumber(),
             $channelCode,
         );


### PR DESCRIPTION
When fetching current contact from omnisend code was checking email instead of phone number, making sure it's not empty, probably a copy/paste error